### PR TITLE
Fix SSL connectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log
+- 1.0.2
+  - Fix for SSL connectivity
 - 1.0.1
 	- Minor updates
 	- Add License file

--- a/lib/tealium_collect.rb
+++ b/lib/tealium_collect.rb
@@ -4,21 +4,22 @@ require 'json'
 
 class TealiumCollect
   LIBRARY_NAME = "ruby"
-  LIBRARY_VERSION = "1.0.0"
+  LIBRARY_VERSION = "1.0.2"
 
   def self.collect(payload)
     uri = URI.parse("https://collect.tealiumiq.com/event")
     header = {'Content-type': 'application/json'}
-    http = Net::HTTP.new(uri.host)
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
     request = Net::HTTP::Post.new(uri.request_uri, header)
     payload[:tealium_library_name] = LIBRARY_NAME
     payload[:tealium_library_version] = LIBRARY_VERSION
 
-      request.body = payload.to_json
-      response = http.request(request)
+    request.body = payload.to_json
+    response = https.request(request)
 
-      #uncomment the line below for debugging
-      #checkRequestResponse(response)
+    #uncomment the line below for debugging
+    #checkRequestResponse(response)
   end
 
   def checkRequestResponse(response)

--- a/tealium.gemspec
+++ b/tealium.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "tealium"
-  s.version = "1.0.1"
+  s.version = "1.0.2"
 
   s.authors = ["Tealium"]
   s.date = %q{2019-01-31}


### PR DESCRIPTION
### Summary
Unable to send events.

Context: [#collect method returns "301 Moved Permanently"](https://github.com/Tealium/tealium-ruby/issues/1)

### Changes
- Specified `uri.port` for `Net::HTTP.new`
- Set flag `use_ssl = true`, as `net-http` lib is forcing request via `http` protocol without that flag